### PR TITLE
fix "daemon.login" passing mandatory "client_version" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Deluge::RPC
 
-Ruby RPC client library for Deluge 2.0+ torrent client.  
-Provides dynamic API bindings depending on RPC server.  
+Ruby RPC client library for [Deluge 2.0+ torrent client](https://deluge-torrent.org/).
+Provides dynamic API bindings depending on RPC server.
 Multi-threading friendly, thanks to ``concurrent-ruby`` gem.
 
-Deluge 1.x is not supported anymore.
+*Deluge 1.x is not supported anymore*.
 
-Official RPC protocol documentation:  
-https://deluge.readthedocs.io/en/latest/reference/rpc.html
+## Reference
 
-Deluge RPC API reference:  
-https://deluge.readthedocs.io/en/latest/reference/api.html
+* [Official RPC protocol documentation](https://deluge.readthedocs.io/en/latest/reference/rpc.html)
+* [Deluge RPC API reference](https://deluge.readthedocs.io/en/latest/reference/api.html)
+* [Official repository](https://github.com/deluge-torrent/deluge)
+* Other client implementations:
+  [Go](https://github.com/gdm85/go-libdeluge),
+  [Python](https://github.com/JohnDoee/deluge-client)
 
 ## Usage
 
@@ -74,10 +77,10 @@ client.register_event(:torrent_removed) do |torrent_id|
 end
 ```
 
-Unfortunately there is no way to listen ALL events, due to Deluge architecture.  
+Unfortunately there is no way to listen ALL events, due to Deluge architecture.
 You have to register each event you need.
 
-**Keep in mind event blocks would be executed in connection thread, NOT main thread!**  
+**Keep in mind event blocks would be executed in connection thread, NOT main thread!**
 Avoid time-consuming code!
 
 ### Known events
@@ -102,7 +105,7 @@ Avoid time-consuming code!
 ``PluginEnabledEvent``        | name                    | Plugin is enabled in the Core.
 ``PluginDisabledEvent``       | name                    | Plugin is disabled in the Core.
 
-This list was extracted from Deluge 1.3.11 sources. Events for your version could be different.  
+This list was extracted from Deluge 1.3.11 sources. Events for your version could be different.
 There is no official documentation.
 
 Current events could be found here:
@@ -118,8 +121,12 @@ gem 'deluge-rpc'
 
 And then execute:
 
-    $ bundle
+```shell
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install deluge-rpc
+```shell
+$ gem install deluge-rpc
+```

--- a/lib/deluge/rpc/connection.rb
+++ b/lib/deluge/rpc/connection.rb
@@ -94,6 +94,7 @@ module Deluge
 
         kwargs = {}
         kwargs = args.pop if args.size == 1 && args.last.is_a?(Hash)
+        kwargs['client_version'] = Deluge::Rpc::VERSION.to_s if method == 'daemon.login'
 
         future = Concurrent::IVar.new
 

--- a/lib/deluge/rpc/connection.rb
+++ b/lib/deluge/rpc/connection.rb
@@ -67,7 +67,7 @@ module Deluge
       end
 
       def authenticate(login, password)
-        self.call(DAEMON_LOGIN, login, password)
+        self.call(DAEMON_LOGIN, [login, password, {'client_version' => Deluge::Rpc::VERSION.to_s}])
       end
 
       def method_list
@@ -93,8 +93,10 @@ module Deluge
         raise "Not connected!" unless @connection
 
         kwargs = {}
-        kwargs = args.pop if args.size == 1 && args.last.is_a?(Hash)
-        kwargs['client_version'] = Deluge::Rpc::VERSION.to_s if method == 'daemon.login'
+        if args.size == 1 && args[0].last.is_a?(Hash)
+          kwargs = args[0].pop
+          args   = args[0]
+        end
 
         future = Concurrent::IVar.new
 

--- a/lib/deluge/rpc/version.rb
+++ b/lib/deluge/rpc/version.rb
@@ -1,5 +1,5 @@
 module Deluge
   module Rpc
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/deluge/rpc/version.rb
+++ b/lib/deluge/rpc/version.rb
@@ -1,5 +1,5 @@
 module Deluge
   module Rpc
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
This patch fixes ISSUE #4 `Deluge::Rpc::Connection::RPCError (IncompatibleClient)`

Deluge version 2 now requires a client_version upon daemon.login method call.

I also added some useful external links in README.md
